### PR TITLE
Simplify circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,11 +127,6 @@ workflows:
         filters:
           tags:
             only: /^v[0-9]+\.[0-9]+$/
-    - github_app:
-        context: familie-ci
-        filters:
-          tags:
-            only: /^v[0-9]+\.[0-9]+$/
     - deploy_dev:
         context: familie-ci
         requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,22 +70,6 @@ jobs:
           paths:
             - properties.env
 
-  github_app:
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    steps:
-      - run:
-          name: Creating Github Apps Installation Token
-          command: |
-            git clone https://github.com/navikt/github-apps-support.git
-            export PATH=`pwd`/github-apps-support/bin:$PATH
-            echo $GITHUB_PRIVATE_KEY | base64 --decode > ./github.key.pem
-            GITHUB_TOKEN=$(generate-installation-token.sh `generate-jwt.sh ./github.key.pem $GITHUB_APP_ID`)
-      - persist_to_workspace:
-          root: .
-          paths:
-            - ./github.key.pem
-
   deploy_dev:
     executor: nais-deployer
     steps:
@@ -102,9 +86,9 @@ jobs:
               --cluster=dev-fss \
               --repository=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
               --appid=${GITHUB_APP_ID} \
+              --key-base64=${GITHUB_PRIVATE_KEY} \
               --team=${TEAM} \
               --version=${VERSION} \
-              --key=/home/circleci/project/github.key.pem \
               --resource=./app-preprod.yaml
 
   deploy_prod:
@@ -123,9 +107,9 @@ jobs:
               --cluster=prod-fss \
               --repository=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
               --appid=${GITHUB_APP_ID} \
+              --key-base64=${GITHUB_PRIVATE_KEY} \
               --team=${TEAM} \
               --version=${VERSION} \
-              --key=/home/circleci/project/github.key.pem \
               --resource=./app-prod.yaml
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,6 @@ workflows:
         context: familie-ci
         requires:
         - deploy_docker
-        - github_app
         filters:
           tags:
             only: /^.*/
@@ -141,7 +140,6 @@ workflows:
         context: familie-ci
         requires:
         - deploy_docker
-        - github_app
         filters:
           branches:
             ignore: /.*/


### PR DESCRIPTION
Removes generation of unused token, and shortcuts sending apps private key by using environment-variable directly.

Note: Can be further simplfied if variable in context named $GITHUB_PRIVATE_KEY either be renamed or copied to variable $GITHUB_APP_KEY_BASE64. This variable is then automatically picked up by deployment-cli, and you don't need to send --key-base64.